### PR TITLE
chore: simplify API in several ways

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,16 +99,9 @@ export class AppModule implements OnModuleInit {
     constructor(@Inject(JSONAPI_MODULE_SERVICE) private readonly jsonapiService: JsonapiService) {}
 
     public async onModuleInit(): Promise<void> {
-        this.jsonapiService.register({
-            name: RESOURCE_PHOTOS,
-            schema: new SchemaBuilder<Photo>(RESOURCE_PHOTOS)
-                .data(
-                    new SchemaDataBuilder<Photo>(RESOURCE_PHOTOS)
-                        .untransformAttributes({ deny: ["createdAt", "updatedAt"] })
-                        .build()
-                )
-                .build(),
-        });
+        const photoBuilder = new SchemaBuilder<Photo>(RESOURCE_PHOTOS);
+        photoBuilder.dataBuilder.untransformAttributes({ deny: ["createdAt", "updatedAt"] });
+        this.jsonapiService.register(photoBuilder);
     }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2123,6 +2123,12 @@
         "dot-prop": "^5.1.0"
       }
     },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -3678,6 +3684,15 @@
         "path-exists": "^4.0.0"
       }
     },
+    "find-versions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "dev": true,
+      "requires": {
+        "semver-regex": "^3.1.2"
+      }
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -4369,10 +4384,70 @@
       "dev": true
     },
     "husky": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-6.0.0.tgz",
-      "integrity": "sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==",
-      "dev": true
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
+      "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.6.0",
+        "cosmiconfig": "^7.0.0",
+        "find-versions": "^4.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^5.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -6410,6 +6485,12 @@
         }
       }
     },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "dev": true
+    },
     "optional": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
@@ -6610,6 +6691,15 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "posix-character-classes": {
@@ -7328,6 +7418,18 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "semver-regex": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
+      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "dev": true
     },
     "send": {
       "version": "0.17.1",
@@ -8760,6 +8862,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-prettier": "3.4.0",
     "faker": "5.5.3",
-    "husky": "6.0.0",
+    "husky": "4.3.8",
     "jest": "26.6.3",
     "jest-junit": "12.0.0",
     "npm-run-all": "4.1.5",

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,10 @@
         {
             "paths": ["+(package.json)"],
             "rangeStrategy": "bump"
+        },
+        {
+            "matchPackageNames": ["husky"],
+            "allowedVersions": "<5"
         }
     ],
     "masterIssue": false,

--- a/src/schema-builder.ts
+++ b/src/schema-builder.ts
@@ -2,16 +2,19 @@ import { DocParams, Schema, SchemaData } from 'transformalizer';
 import { SchemaDataBuilder } from './schema-data-builder';
 
 export class SchemaBuilder<Resource = unknown> {
+    public readonly dataBuilder: SchemaDataBuilder<Resource>;
     private readonly bindings: Schema = {};
 
-    constructor(public readonly typeName: string) {}
+    constructor(public readonly resourceName: string) {
+        this.dataBuilder = new SchemaDataBuilder<Resource>(resourceName);
+    }
 
     public build(): Schema {
         const schema: Schema = {};
         // defer to default bindings if nothing was provided
         schema.links = this.bindings.links ?? this._links.bind(this);
         schema.meta = this.bindings.meta ?? this._meta.bind(this);
-        schema.data = this.bindings.data ?? new SchemaDataBuilder<Resource>(this.typeName).build();
+        schema.data = this.bindings.data ?? this.dataBuilder.build();
         return schema;
     }
 

--- a/src/schema-data-builder.ts
+++ b/src/schema-data-builder.ts
@@ -43,7 +43,7 @@ interface AllowDeny<T> {
 export class SchemaDataBuilder<Resource = unknown> {
     private readonly bindings: SchemaData = {};
 
-    constructor(private readonly typeName: string) {}
+    constructor(private readonly resourceName: string) {}
 
     public static includeHasManyRelationship(
         params: SerializeRelationshipsDataParams,
@@ -184,7 +184,7 @@ export class SchemaDataBuilder<Resource = unknown> {
     }
 
     private _type(): string {
-        return this.typeName;
+        return this.resourceName;
     }
 
     private _attributes(options?: {


### PR DESCRIPTION
- support registering a builder
- provide a default SchemaDataBuilder to a SchemaBuilder
- remove the canTransform method on the JsonapiTransformer interface
it is confusing, error-prone, and better to be explicit and require the resourceName