### PR TITLE
feat: expose some untransform options via the payload-decorator

### DIFF
--- a/src/payload-decorator.ts
+++ b/src/payload-decorator.ts
@@ -4,6 +4,9 @@ import { METADATA_KEY_JSONAPI_PAYLOAD } from './constants';
 export interface JsonapiPayloadOptions {
     resource?: string;
     untransformArray?: boolean;
+    untransformIncluded?: boolean;
+    nestIncluded?: boolean;
+    removeCircularDependencies?: boolean;
 }
 
 export const JsonapiPayload = (options?: JsonapiPayloadOptions): CustomDecorator =>

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -5,6 +5,7 @@ import { REQUEST } from '@nestjs/core';
 import { Request } from 'express';
 import { JSONAPI_MODULE_SERVICE } from './constants';
 import { assertIsDefined } from './utils';
+import { JsonapiPayloadOptions } from './payload-decorator';
 
 /**
  * This {@link PipeTransform} uses a {@link JsonapiService} to untransform the input payload
@@ -17,10 +18,17 @@ export class JsonapiPipe implements PipeTransform {
     ) {}
 
     public transform(value: JSONAPIDocument): ParsedJsonAPIResult | unknown {
-        const untransformed = this.jsonapiService.untransform(value);
+        const jsonapiRequestHolder: JsonapiPayloadOptions = this.request.jsonapiRequestHolder;
 
-        const jsonapiRequestHolder = this.request.jsonapiRequestHolder;
-        if (!jsonapiRequestHolder) {
+        const options = {
+            untransformIncluded: jsonapiRequestHolder?.untransformIncluded,
+            nestIncluded: jsonapiRequestHolder?.nestIncluded,
+            removeCircularDependencies: jsonapiRequestHolder?.removeCircularDependencies
+        };
+
+        const untransformed = this.jsonapiService.untransform(value, options);
+
+        if (!jsonapiRequestHolder || jsonapiRequestHolder.untransformIncluded) {
             return untransformed;
         }
 

--- a/src/request-holder.ts
+++ b/src/request-holder.ts
@@ -1,6 +1,6 @@
 import { JsonapiPayloadOptions } from './payload-decorator';
 
-export class JsonapiRequestHolder {
+export class JsonapiRequestHolder implements JsonapiPayloadOptions {
     private payloadOptions: JsonapiPayloadOptions | undefined;
 
     public get resource(): string | undefined {
@@ -11,7 +11,31 @@ export class JsonapiRequestHolder {
         return !!this.payloadOptions?.untransformArray;
     }
 
-    public set({ resource, untransformArray }: JsonapiPayloadOptions): void {
-        this.payloadOptions = { resource, untransformArray };
+    public get untransformIncluded(): boolean {
+        return !!this.payloadOptions?.untransformIncluded;
+    }
+
+    public get nestIncluded(): boolean {
+        return !!this.payloadOptions?.nestIncluded;
+    }
+
+    public get removeCircularDependencies(): boolean {
+        return !!this.payloadOptions?.removeCircularDependencies;
+    }
+
+    public set({
+        resource,
+        untransformArray,
+        untransformIncluded,
+        nestIncluded,
+        removeCircularDependencies
+    }: JsonapiPayloadOptions): void {
+        this.payloadOptions = {
+            resource,
+            untransformArray,
+            untransformIncluded,
+            nestIncluded,
+            removeCircularDependencies
+        };
     }
 }


### PR DESCRIPTION
- untransformIncluded
- nestIncluded
- removeCircularDependencies

Additionally, if untransformIncluded is true, the full untransformed payload is returned
from the JsonapiPipe

This allows APIs to support an included array when sideloading new relationships