### PR TITLE
fix: empty array relationships should not be skipped

### DIFF
--- a/src/schema-data-builder.ts
+++ b/src/schema-data-builder.ts
@@ -53,7 +53,7 @@ export class SchemaDataBuilder<Resource = unknown> {
     ): Relationship | undefined {
         const { data } = params;
         const relation = data[field];
-        if (relation && Array.isArray(relation) && relation.length) {
+        if (relation && Array.isArray(relation)) {
             return {
                 // @ts-ignore
                 data: data[field].map((obj: unknown) => ({

--- a/tests/service.spec.ts
+++ b/tests/service.spec.ts
@@ -346,6 +346,16 @@ describe('jsonapi service', () => {
             expect(included.length).toBe(2);
         });
 
+        it('empty array relationships are included', () => {
+            const album = new Album('faves', []);
+            const result = service.transform({ source: album, resourceName: RESOURCE_ALBUMS });
+
+            const data = result.data as Dictionary;
+            expectModel(data, album, RESOURCE_ALBUMS);
+            expect(data.relationships).toBeDefined();
+            expect((data.relationships as Dictionary).photos).toBeDefined();
+        });
+
         it('hasMany relationship, not included', () => {
             // re-register, but do not include the photos in the payload
             service.register({


### PR DESCRIPTION
https://jsonapi.org/format/#document-resource-object-linkage